### PR TITLE
auto configure worlds

### DIFF
--- a/Code/src/main/java/com/github/happyuky7/separeworlditems/listeners/base/WorldChangeEvent.java
+++ b/Code/src/main/java/com/github/happyuky7/separeworlditems/listeners/base/WorldChangeEvent.java
@@ -59,7 +59,18 @@ public class WorldChangeEvent implements Listener {
         String toWorld = player.getWorld().getName(); // Target world
 
         FileConfiguration config = plugin.getConfig();
-
+        
+        // Check if we should add missing worlds to the config
+        if (config.getBoolean("settings.auto-configure-worlds", false)) {
+        	String default_group = config.getString("options.default-groups");
+        	if (!config.contains("worlds." + fromWorld)) {
+        		config.set("worlds." + fromWorld, default_group);
+        	}
+        	if (!config.contains("worlds." + toWorld)) {
+        		config.set("worlds." + toWorld, default_group);
+        	}
+        }
+        
         // Check if the worlds are configured in the plugin's settings
         if (config.contains("worlds." + fromWorld) && config.contains("worlds." + toWorld)) {
             // Retrieve the world groups the player is switching between

--- a/Code/src/main/resources/config.yml
+++ b/Code/src/main/resources/config.yml
@@ -15,6 +15,8 @@ settings:
   langs:
     lang: en_US
     auto-download: true #Auto download language files. (Recommended ENABLE)
+	
+  auto-configure-worlds: false # Should we add missing worlds to the config
 
 
 experimental:


### PR DESCRIPTION
adds an option to the config for adding missing worlds to the default group automatically.